### PR TITLE
Fixed strings in pokemon cheats to match utf-8 encoding

### DIFF
--- a/atmosphere/titles/010003F003A34000/cheats/1C375692DE4F4B87.txt
+++ b/atmosphere/titles/010003F003A34000/cheats/1C375692DE4F4B87.txt
@@ -1,13 +1,13 @@
-[All Pokémon Shiny (Hold B) (Handheld Only)]
+[All PokÃ©mon Shiny (Hold B) (Handheld Only)]
 04000000 00739994 540002e0
 80000002
 04000000 00739994 14000027
 20000000
 
-[All Pokémon Shiny Always]
+[All PokÃ©mon Shiny Always]
 04000000 00739994 14000027
 
-[Normal Pokémon Shiny Odds]
+[Normal PokÃ©mon Shiny Odds]
 04000000 00739994 540002e0
 
 [Max Money]

--- a/atmosphere/titles/0100187003A36000/cheats/0a3f0d21e67dad80.txt
+++ b/atmosphere/titles/0100187003A36000/cheats/0a3f0d21e67dad80.txt
@@ -1,13 +1,13 @@
-[All Pokémon Shiny (Hold B) (Handheld Only)]
+[All PokÃ©mon Shiny (Hold B) (Handheld Only)]
 04000000 007399f4 540002e0
 80000002
 04000000 007399f4 14000027
 20000000
 
-[All Pokémon Shiny Always]
+[All PokÃ©mon Shiny Always]
 04000000 007399f4 14000027
 
-[Normal Pokémon Shiny Odds]
+[Normal PokÃ©mon Shiny Odds]
 04000000 007399f4 540002e0
 
 [Max Money]


### PR DESCRIPTION
Having ANSI encoding may bring trouble in the future when trying to read these files.